### PR TITLE
More robust generation of ensembles

### DIFF
--- a/molnsutil/molnsutil.py
+++ b/molnsutil/molnsutil.py
@@ -747,7 +747,7 @@ class DistributedEnsemble():
         if num_engines == None:
             self.lv = self.c.load_balanced_view()
         else:
-            max_num_engines = len(c.ids)
+            max_num_engines = len(self.c.ids)
             if num_engines > max_num_engines:
                 engines = max_num_engines
             else:


### PR DESCRIPTION
By setting the max number of times a failed task is retried the DistributedEnsemble can recover from engines dying. I have verified this behavior in EC2 by manually killing an entire worker VM. 
